### PR TITLE
fix(rain): Stagger initial rain drop animation

### DIFF
--- a/js/rain/engine.js
+++ b/js/rain/engine.js
@@ -134,8 +134,15 @@ export function setupRain() {
 
   streams = ACTIVE_COL_INDICES.map((index) => new Stream(index));
 
+  // The streams are created with a synchronized starting position from their
+  // reset() method. To fix the initial "batch" drop, we loop through them
+  // once and give each a widely randomized starting head position.
+  // This ensures they enter the screen at different times from frame 1.
+  for (const s of streams) {
+    s.head = -randInt(ROWS * 2); // Using ROWS * 2 provides a large, random, off-screen starting range.
+  }
+
   matrixRainCtx.shadowColor = CFG.headCol; // Initial shadow color
-  // console.log("Rain setup complete. Columns:", TOTAL_COLS, "Rows:", ROWS, "Active Streams:", streams.length);
 }
 
 function rainTick() {


### PR DESCRIPTION
The initial batch of rain streams appeared synchronized because they were
all created with similar starting positions.

This fix adds a loop within setupRain() to explicitly assign a widely
randomized negative 'head' position to each stream upon creation.
This ensures the rain appears naturally staggered from the first frame,
resolving the synchronized 'batch drop' effect.
