### PR TITLE
feat(engine): smooth RAF animation + dynamic help & misc polish

### DIFF
--- a/js/commands/0_index.js
+++ b/js/commands/0_index.js
@@ -32,7 +32,7 @@ import whoamiCommand from "./whoami.js";
  * @returns {object} An object mapping command names to their functions.
  */
 export function getAllCommands() {
-  return {
+  const cmds = {
     clear: clearCommand,
     contact: contactCommand,
     date: dateCommand,
@@ -53,6 +53,8 @@ export function getAllCommands() {
     toggleterm: toggleTermCommand,
     whoami: whoamiCommand,
   };
+
+  return cmds;
 }
 
 // Utility function for rendering tree structures (skills, hobbies)

--- a/js/commands/clear.js
+++ b/js/commands/clear.js
@@ -2,6 +2,7 @@
  * @file js/commands/clear.js
  * Handles the 'clear' command.
  */
+
 export default function clearCommand(args, context) {
   const { terminalController } = context; // Or directly get clearTerminalOutput if preferred
   terminalController.clearTerminalOutput();

--- a/js/commands/date.js
+++ b/js/commands/date.js
@@ -68,9 +68,7 @@ function getFormattedDateTime(date, timeZoneIana, locale = "en-US") {
     return date.toLocaleString(locale, options);
   } catch {
     // Fallback if timezone is invalid for toLocaleString
-    console.warn(
-      `Error formatting date for timezone ${timeZoneIana}: ${e.message}`,
-    );
+    console.warn(`Error formatting date for timezone ${timeZoneIana}:`);
     if (timeZoneIana) {
       // Try with just UTC offset as a last resort for display if IANA failed
       try {
@@ -131,7 +129,7 @@ export default function dateCommand(args, context) {
             "output-date-wrapper",
           );
         }
-      } catch (e) {
+      } catch {
         appendToTerminal(
           `<div class="output-error">Unknown timezone alias or invalid IANA name: '${args[0]}'.</div>`,
           "output-error-wrapper",

--- a/js/commands/screenshot.js
+++ b/js/commands/screenshot.js
@@ -5,6 +5,7 @@
  * Captures a *full‑HD* (1920 × 1080) PNG of the Matrix‑rain canvas only,
  * leaves the animation loop running, and force‑downloads the file.
  */
+
 export default function screenshotCommand(args, context) {
   const { appendToTerminal } = context;
   const srcCanvas = document.getElementById("matrix-canvas");
@@ -17,10 +18,8 @@ export default function screenshotCommand(args, context) {
     return;
   }
 
-  /* ---------------------------------------------------------------------
-     Prepare an off‑screen canvas at the target resolution to avoid any
-     write‑lock on the on‑screen canvas (which would jank the animation).
-  --------------------------------------------------------------------- */
+  // Prepare an off‑screen canvas at the target resolution to avoid any
+  // write‑lock on the on‑screen canvas (which would jank the animation).
   const TARGET_W = 1920;
   const TARGET_H = 1080;
   const offCanvas = document.createElement("canvas");
@@ -28,11 +27,10 @@ export default function screenshotCommand(args, context) {
   offCanvas.height = TARGET_H;
   const offCtx = offCanvas.getContext("2d");
 
-  /* Draw the live rain canvas onto the off‑screen surface, scaling if
-     necessary.  The src canvas keeps rendering in parallel. */
+  // Draw the live rain canvas onto the off‑screen surface, scaling if necessary.
+  // The src canvas keeps rendering in parallel. */
   offCtx.drawImage(srcCanvas, 0, 0, TARGET_W, TARGET_H);
 
-  /* ------------------------------------------------------------------ */
   offCanvas.toBlob((blob) => {
     if (!blob) {
       appendToTerminal(
@@ -41,7 +39,7 @@ export default function screenshotCommand(args, context) {
       );
       return;
     }
-    /* Build a safe filename: rain_screenshot_2025‑07‑19T18‑29‑55.png */
+    // Build a safe filename: rain_screenshot_2025‑07‑19T18‑29‑55.png
     const ts = new Date().toISOString().replace(/[:.]/g, "-");
     const fileName = `rain_screenshot_${ts}.png`;
 
@@ -51,7 +49,7 @@ export default function screenshotCommand(args, context) {
     document.body.appendChild(link);
     link.click();
 
-    /* House‑keeping: revoke URL & remove anchor after the download fires. */
+    // House‑keeping: revoke URL & remove anchor after the download fires.
     setTimeout(() => {
       URL.revokeObjectURL(link.href);
       link.remove();

--- a/js/controller/terminalController.js
+++ b/js/controller/terminalController.js
@@ -317,15 +317,18 @@ function getArgumentSuggestions(commandName, context, currentInput) {
         "reloaded",
         "voidblue",
       ].sort();
-    case "rainpreset":
+    case "rainpreset": {
       const presets =
         context.rainOptions && context.rainOptions.getRainPresets
           ? Object.keys(context.rainOptions.getRainPresets())
           : [];
       return presets.sort();
-    case "man":
+    }
+    case "man": {
       const manPageKeys = context.manPages ? Object.keys(context.manPages) : [];
       return manPageKeys.sort();
+    }
+
     case "resize":
       if (inputParts.length === 2 && inputParts[1] === "term") return ["reset"]; // Suggest 'reset' after 'resize term'
       if (inputParts.length === 1) return ["term"]; // Suggest 'term' after 'resize'
@@ -333,7 +336,7 @@ function getArgumentSuggestions(commandName, context, currentInput) {
     case "download":
       if (inputParts.length === 1) return ["cv"];
       return [];
-    case "date":
+    case "date": {
       // Assuming context.dateCommandTimezoneAliases is populated if available
       // For this example, using a placeholder. In a real scenario, this data should be accessible.
       const timezoneAliases = context.dateCommandTimezoneAliases || [
@@ -345,6 +348,7 @@ function getArgumentSuggestions(commandName, context, currentInput) {
         "gmt",
       ];
       return timezoneAliases.sort();
+    }
     default:
       return [];
   }

--- a/js/main.js
+++ b/js/main.js
@@ -93,7 +93,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     );
   });
 
-  // --- START OF CORRECTION ---
   // This replaces the original hideLoadingScreen call.
   // It waits for both the loading screen to be hidden AND for the fonts to be ready.
   Promise.all([
@@ -116,11 +115,21 @@ document.addEventListener("DOMContentLoaded", async () => {
     .catch((error) => {
       console.error("Error during final initialization step:", error);
     });
-  // --- END OF CORRECTION ---
 
-  window.addEventListener("resize", () => {
-    rainEngine.setupRain();
-  });
+  /*  debounce resize to prevent setupRain storm */
+  const debounce = (fn, delay = 150) => {
+    let t;
+    return (...a) => {
+      clearTimeout(t);
+      t = setTimeout(() => fn(...a), delay);
+    };
+  };
+  window.addEventListener(
+    "resize",
+    debounce(() => {
+      rainEngine.setupRain();
+    }, 150),
+  );
 
   // Update navigation links
   const navCvLink = document.getElementById("nav-cv-link");


### PR DESCRIPTION
Core:
* Replace `setTimeout` loop with `requestAnimationFrame` (`rainLoop`)
  * honours `CFG.speed` with delta timing
  * draws first frame immediately to avoid blank‑screen glitch
* Re‑init colours/streams in `startRainAnimation` and `refreshRainVisuals`
* Debounce `setupRain()` on `resize` (150 ms) to cut jank


No layout or API regressions; rain starts instantly and stays smooth.
