### PR TITLE
feat: Direction A — NEURAL-STORM theme, mission command, recruiter mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -612,6 +612,44 @@ body.terminal-hidden .minimal-nav #nav-toggle-term {
   bottom: 135%;
 }
 
+/* Recruiter mode: highlight nav bar */
+@keyframes recruiter-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+body.recruiter-mode .minimal-nav {
+  background-color: rgba(
+    var(--terminal-base-r),
+    var(--terminal-base-g),
+    var(--terminal-base-b),
+    0.45
+  );
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(var(--primary-color-rgb), 0.25);
+}
+
+body.recruiter-mode .minimal-nav #nav-cv-link,
+body.recruiter-mode .minimal-nav #nav-email-link,
+body.recruiter-mode .minimal-nav #nav-github-link {
+  color: var(--hover-color);
+  text-shadow: 0 0 10px var(--text-shadow-color);
+  animation: recruiter-pulse 2s ease-in-out infinite;
+}
+
+body.recruiter-mode .minimal-nav #nav-cv-link {
+  animation-delay: 0s;
+}
+
+body.recruiter-mode .minimal-nav #nav-email-link {
+  animation-delay: 0.3s;
+}
+
+body.recruiter-mode .minimal-nav #nav-github-link {
+  animation-delay: 0.6s;
+}
+
 .terminal-glitch-overlay {
   position: absolute;
   top: 0;

--- a/css/themes.css
+++ b/css/themes.css
@@ -31,17 +31,6 @@ body.theme-green {
   --terminal-base-b: 39;
 }
 
-body.theme-cyan {
-  --primary-color: #0ff;
-  --primary-color-rgb: 0, 255, 255;
-  --secondary-color: #0f0;
-  --hover-color: #5fffff;
-  --matrix-rain-glow-color: #afffff;
-  --background-color: #000505;
-  --terminal-base-r: 0;
-  --terminal-base-g: 20;
-  --terminal-base-b: 20;
-}
 
 body.theme-amber {
   --primary-color: #ffbf00;
@@ -160,5 +149,18 @@ body.theme-ember {
   --terminal-base-r: 28;
   --terminal-base-g: 8;
   --terminal-base-b: 4;
+}
+
+/* NEURAL-STORM – dual-color cyan + magenta chaos */
+body.theme-neuralstorm {
+  --primary-color: #00f0ff;
+  --primary-color-rgb: 0, 240, 255;
+  --secondary-color: #ff0055;
+  --hover-color: #60ffff;
+  --matrix-rain-glow-color: #b0ffff;
+  --background-color: #020005;
+  --terminal-base-r: 5;
+  --terminal-base-g: 0;
+  --terminal-base-b: 15;
 }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
         setInterval: "readonly",
         clearInterval: "readonly",
         URL: "readonly",
+        URLSearchParams: "readonly",
         HTMLElement: "readonly",
         Event: "readonly",
         KeyboardEvent: "readonly",

--- a/js/commands/0_index.js
+++ b/js/commands/0_index.js
@@ -13,6 +13,7 @@ import easterEggCommand from "./easter.egg.js";
 import helpCommand from "./help.js";
 import hobbiesCommand from "./hobbies.js";
 import manCommand from "./man.js";
+import missionCommand from "./mission.js";
 import rainFontCommand from "./rainfont.js";
 import rainPresetCommand from "./rainpreset.js";
 import rainSizeCommand from "./rainsize.js";
@@ -44,6 +45,8 @@ export function getAllCommands() {
     help: helpCommand,
     hobbies: hobbiesCommand,
     man: manCommand,
+    mission: missionCommand,
+    hire: missionCommand,
     rainfont: rainFontCommand,
     rainpreset: rainPresetCommand,
     rainsize: rainSizeCommand,

--- a/js/commands/mission.js
+++ b/js/commands/mission.js
@@ -1,0 +1,43 @@
+/**
+ * @file js/commands/mission.js
+ * Handles the 'mission' command — recruiter dossier with nav highlight.
+ * Running again toggles recruiter mode off.
+ */
+
+import { escapeHtml } from "../utils.js";
+
+export default function missionCommand(args, context) {
+  const { appendToTerminal, config } = context;
+
+  // Toggle recruiter mode
+  if (document.body.classList.contains("recruiter-mode")) {
+    document.body.classList.remove("recruiter-mode");
+    appendToTerminal(
+      `<div class="output-success">Recruiter mode disengaged.</div>`,
+    );
+    return;
+  }
+
+  document.body.classList.add("recruiter-mode");
+
+  const user = config.user;
+  const name = escapeHtml(user.name || "OPERATOR");
+  const title = escapeHtml(user.title || "System Analyst");
+  const bio = escapeHtml(user.bio || "");
+
+  const output =
+    `<div class="output-section-title section-title-plain"><i class="fas fa-user-secret icon-inline"></i> DOSSIER &mdash; ${name}</div>` +
+    `<div class="output-section">` +
+    `<div class="output-line"><span class="output-line-label">Identity:</span> ${name}</div>` +
+    `<div class="output-line"><span class="output-line-label">Role:</span> ${title}</div>` +
+    `<div class="output-line"><span class="output-line-label">Status:</span> <span class="output-success">AVAILABLE FOR HIRE</span></div>` +
+    `</div>` +
+    `<div class="output-section">` +
+    `<div class="output-line">${bio}</div>` +
+    `</div>` +
+    `<div class="mt-section output-text-small">` +
+    `<span class="output-success">skills</span> &middot; <span class="output-success">whoami</span> &middot; <span class="output-success">contact</span> &middot; <span class="output-success">download cv</span>` +
+    `</div>`;
+
+  appendToTerminal(output);
+}

--- a/js/config/index.js
+++ b/js/config/index.js
@@ -215,6 +215,11 @@ export const help = {
       desc: "Show detailed manual for a command.",
     },
     {
+      cmd: "mission",
+      display: "mission",
+      desc: "Recruiter dossier — profile summary and quick links.",
+    },
+    {
       cmd: "rainfont <name>",
       display: "rainfont <name>",
       desc: (context) =>
@@ -282,12 +287,12 @@ export const help = {
   availableThemes: [
     "amber",
     "crimson",
-    "cyan",
     "ember",
     "ghost",
     "green",
     "inferno",
     "midnight",
+    "neuralstorm",
     "phantom",
     "reloaded",
     "sakura",

--- a/js/main.js
+++ b/js/main.js
@@ -114,6 +114,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     );
   });
 
+  // Detect recruiter mode via URL path, hash, or query param
+  const isRecruiterMode =
+    window.location.pathname.replace(/\/$/, "").endsWith("/recruiter") ||
+    window.location.hash === "#recruiter" ||
+    new URLSearchParams(window.location.search).get("mode") === "recruiter";
+
   Promise.all([
     new Promise((resolve) => hideLoadingScreen(resolve)),
     document.fonts.ready,
@@ -124,6 +130,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
       rainEngine.start();
       terminalController.focusInput();
+
+      if (isRecruiterMode) {
+        setTimeout(() => {
+          registeredCommands.mission([], commandContext);
+        }, 400);
+      }
     })
     .catch((error) => {
       console.error("Error during final initialization step:", error);

--- a/public/config/content/manPages.json
+++ b/public/config/content/manPages.json
@@ -191,12 +191,23 @@
     "description": "Switches the visual theme of the terminal and Matrix rain animation. Affects text, backgrounds, UI elements, and rain colors. Running 'theme' without arguments lists available themes and the current one.",
     "arguments": "[theme_name]: Optional. The name of the theme to apply. If omitted, current and available themes are listed.",
     "examples": [
-      "theme cyan         - Switches to the cyan theme.",
+      "theme neuralstorm  - Switches to the neural-storm theme.",
       "theme reloaded     - Switches to the reloaded theme.",
       "theme              - Shows current and available themes."
     ],
-    "available_themes": "amber, crimson, cyan, ember, ghost, green (default), inferno, midnight, phantom, reloaded, sakura.",
-    "notes": "Theme changes also update the Matrix rain colors for a cohesive look."
+    "available_themes": "amber, crimson, ember, ghost, green (default), inferno, midnight, neuralstorm, phantom, reloaded, sakura.",
+    "notes": "Theme changes also update the Matrix rain colors for a cohesive look. NEURAL-STORM is dual-color cyan + magenta."
+  },
+  "mission": {
+    "name": "mission - Display recruiter dossier and enable recruiter mode.",
+    "synopsis": "mission",
+    "description": "Displays a professional dossier summary with identity, role, and status. Designed for recruiters and hiring managers. Alias: 'hire'.",
+    "arguments": "None",
+    "examples": [
+      "mission            - Activates recruiter mode with dossier.",
+      "hire               - Same as mission."
+    ],
+    "notes": "Recruiter mode can also be triggered automatically by visiting the site with #recruiter in the URL or ?mode=recruiter query parameter."
   },
   "toggleterm": {
     "name": "toggleterm - Hide or show the terminal window.",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  appType: "spa",
+});


### PR DESCRIPTION
## Summary
- **NEURAL-STORM theme**: electric cyan primary + glitch magenta accents on deep void purple background (replaces cyan which was too similar)
- **`mission` / `hire` command**: toggleable recruiter mode — prints a professional dossier in the terminal and highlights the bottom nav bar (CV, Email, GitHub icons get a pulsing glow + frosted glass backdrop)
- **Recruiter auto-mode**: visiting via `/recruiter` path, `#recruiter` hash, or `?mode=recruiter` query param auto-triggers mission on page load
- **SPA routing**: added vite.config.js with `appType: 'spa'` so `/recruiter` path serves index.html
- Updated help listing, man pages, and ESLint globals

## Test plan
- [ ] `theme neuralstorm` — cyan rain, magenta terminal accents, deep purple bg
- [ ] `mission` — dossier prints, bottom nav gets frosted glass + pulsing CV/Email/GitHub icons
- [ ] `mission` again — disengages recruiter mode, nav returns to normal
- [ ] `localhost:5173/recruiter` — auto-triggers mission on page load
- [ ] `hire` — alias works same as mission
- [ ] `man mission` and `help` — both list the new command