### PR TITLE
fix(meta): correct og: URLs to rvs23.dev (Cloudflare domain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Matrix Terminal Portfolio
 
+**🔗 Live:** [rvs23.dev](https://rvs23.dev/)
+
 ## 1. Project Overview
 
 Welcome to my personal portfolio, reimagined as a Matrix-themed interactive terminal. This project departs from traditional portfolio layouts to offer a different user experience. This was purely built out of personal interest & an ever-_green_ love for The Matrix.

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
     <meta property="og:title" content="Rv's Matrix Terminal Portfolio" />
     <meta property="og:description" content="A Matrix-themed interactive terminal portfolio. Type commands to explore." />
     <!-- Social scrapers require absolute URLs. Update this base if the site
-         moves to a custom domain or a different host. -->
-    <meta property="og:url" content="https://rvs-23.github.io/rv-matrix-themed-portfolio/" />
-    <meta property="og:image" content="https://rvs-23.github.io/rv-matrix-themed-portfolio/favicon/rv-matrix-style-favicon-1.png" />
+         moves to a different domain or host. -->
+    <meta property="og:url" content="https://rvs23.dev/" />
+    <meta property="og:image" content="https://rvs23.dev/favicon/rv-matrix-style-favicon-1.png" />
     <meta name="twitter:card" content="summary" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## What
`og:url` and `og:image` in `index.html` were set (in v1.1.0's C12) to a guessed **GitHub Pages** URL. The site actually deploys to **Cloudflare at https://rvs23.dev/**, so link-preview cards pointed at the wrong/likely-dead host.

## Change
- `og:url` → `https://rvs23.dev/`
- `og:image` → `https://rvs23.dev/favicon/rv-matrix-style-favicon-1.png`

Two lines, no logic. The app itself was unaffected (Vite base is `/`, correct for the root deploy) — only the social meta tags were wrong.

## After merge
Deploys from `main` via Cloudflare. Validate the card with the [OpenGraph debugger](https://www.opengraph.xyz/) or X's card validator once live.